### PR TITLE
Removed deprecated SpanContext::withDebugId

### DIFF
--- a/src/Jaeger/Codec/TextCodec.php
+++ b/src/Jaeger/Codec/TextCodec.php
@@ -114,7 +114,7 @@ class TextCodec implements CodecInterface
 
         if ($traceId === null) {
             if ($debugId !== null) {
-                return SpanContext::withDebugId($debugId);
+                return new SpanContext(null, null, null, null, [], $debugId);
             }
             return null;
         }

--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -156,6 +156,8 @@ class Span implements OTSpan
 
     /**
      * {@inheritdoc}
+     *
+     * @return SpanContext
      */
     public function getContext()
     {
@@ -180,16 +182,15 @@ class Span implements OTSpan
     }
 
     /**
+     * Returns true if the trace should be measured.
+     *
      * @return bool
      */
     public function isSampled(): bool
     {
         $context = $this->getContext();
-        if ($context instanceof SpanContext) {
-            return $context->getFlags() & SAMPLED_FLAG == SAMPLED_FLAG;
-        }
 
-        return false;
+        return ($context->getFlags() & SAMPLED_FLAG) == SAMPLED_FLAG;
     }
 
     /**

--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -24,34 +24,22 @@ class SpanContext implements OTSpanContext
 
     /**
      * SpanContext constructor.
+     *
      * @param string $traceId
      * @param string $spanId
      * @param string $parentId
-     * @param $flags
+     * @param int|null $flags
      * @param array $baggage
+     * @param int|null $debugId
      */
-    public function __construct($traceId, $spanId, $parentId, $flags, $baggage = [])
+    public function __construct($traceId, $spanId, $parentId, $flags = null, $baggage = [], $debugId = null)
     {
         $this->traceId = $traceId;
         $this->spanId = $spanId;
         $this->parentId = $parentId;
         $this->flags = $flags;
         $this->baggage = $baggage;
-        $this->debugId = null;
-    }
-
-    /**
-     * TODO
-     * @deprecated
-     * @param $debugId
-     * @return SpanContext
-     */
-    public static function withDebugId($debugId)
-    {
-        $ctx = new SpanContext(null, null, null, null);
-        $ctx->debugId = $debugId;
-
-        return $ctx;
+        $this->debugId = $debugId;
     }
 
     /**
@@ -72,6 +60,10 @@ class SpanContext implements OTSpanContext
 
     /**
      * {@inheritdoc}
+     *
+     * @param string $key
+     * @param string $value
+     * @return SpanContext
      */
     public function withBaggageItem($key, $value)
     {
@@ -93,6 +85,11 @@ class SpanContext implements OTSpanContext
         return $this->spanId;
     }
 
+    /**
+     * Get the span context flags.
+     *
+     * @return int|null
+     */
     public function getFlags()
     {
         return $this->flags;

--- a/tests/Jaeger/SpanContextTest.php
+++ b/tests/Jaeger/SpanContextTest.php
@@ -8,7 +8,7 @@ class SpanContextTest extends TestCase
 {
     public function test_is_debug_id_container_only()
     {
-        $ctx = SpanContext::withDebugId('value1');
+        $ctx = new SpanContext(null, null, null, null, [], 'value1');
         $this->assertTrue($ctx->isDebugIdContainerOnly());
         $this->assertEquals($ctx->getDebugId(), 'value1');
 

--- a/tests/Jaeger/SpanTest.php
+++ b/tests/Jaeger/SpanTest.php
@@ -28,6 +28,23 @@ class SpanTest extends TestCase
     }
 
     /** @test */
+    public function shouldProperlyInitializeAtConstructTime()
+    {
+        $tags = [
+            'foo-1' => 'test-component-1',
+            'foo-2' => 'test-component-2',
+            'foo-3' => 'test-component-3',
+        ];
+
+        $span = new Span($this->context, $this->tracer, 'test-operation', $tags);
+
+        $this->assertEquals( 3, count($span->getTags()));
+        $this->assertEquals($this->tracer, $span->getTracer());
+        $this->assertEquals(false, $span->isDebug());
+        $this->assertEquals(null, $span->getEndTime());
+    }
+
+    /** @test */
     public function shouldSetComponentThroughTag()
     {
         $span = new Span($this->context, $this->tracer, 'test-operation');
@@ -40,6 +57,7 @@ class SpanTest extends TestCase
 
         $this->assertEquals( 0, count($span->getTags()));
         $this->assertEquals( 'libredis', $component->getValue($span));
+        $this->assertEquals( 'libredis', $span->getComponent());
     }
 
     /** @test */


### PR DESCRIPTION
- Removed deprecated `SpanContext::withDebugId`
- Cleaned up `Span::isSampled` (the `Span::getContext` always will return an SpanContext instance)
- Increase test coverage (https://github.com/jonahgeorge/jaeger-client-php/issues/3)