### PR TITLE
Do not throw exception on Tracer::extract

### DIFF
--- a/src/Jaeger/Tracer.php
+++ b/src/Jaeger/Tracer.php
@@ -248,23 +248,24 @@ class Tracer implements OTTracer
     /**
      * {@inheritdoc}
      *
-     * @todo All exceptions thrown from this method should be caught and logged on WARN level so
-     *       that business code execution isn't affected. If possible, catch implementation specific
-     *       exceptions and log more meaningful information.
-     *
      * @param mixed $carrier
      * @return SpanContext|null
-     *
-     * @throws UnsupportedFormat
      */
     public function extract($format, $carrier)
     {
         $codec = $this->codecs[$format] ?? null;
+
         if ($codec == null) {
-            throw new UnsupportedFormat('Unsupported format: ' . $format);
+            $this->logger->warning('Unsupported format: ' . $format);
         }
 
-        return $codec->extract($carrier);
+        try {
+            return $codec->extract($carrier);
+        } catch (\Throwable $e) {
+            $this->logger->warning($e->getMessage());
+
+            return null;
+        }
     }
 
     /**

--- a/tests/Jaeger/Codec/TextCodecTest.php
+++ b/tests/Jaeger/Codec/TextCodecTest.php
@@ -42,7 +42,7 @@ class TextCodecTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessage Malformed tracer state string
      */
     public function testInvalidSpanContextParsingFromHeader()

--- a/tests/Jaeger/ScopeTest.php
+++ b/tests/Jaeger/ScopeTest.php
@@ -10,12 +10,12 @@ use PHPUnit\Framework\TestCase;
 class ScopeTest extends TestCase
 {
     /**
-     * @var ScopeManager
+     * @var ScopeManager|\PHPUnit\Framework\MockObject\MockObject
      */
     private $scopeManager;
 
     /**
-     * @var Span
+     * @var Span|\PHPUnit\Framework\MockObject\MockObject
      */
     private $span;
 

--- a/tests/Jaeger/TracerTest.php
+++ b/tests/Jaeger/TracerTest.php
@@ -8,23 +8,24 @@ use Jaeger\Sampler\SamplerInterface;
 use Jaeger\Scope;
 use Jaeger\ScopeManager;
 use Jaeger\Span;
+use Jaeger\SpanContext;
 use Jaeger\Tracer;
-use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\NoopSpanContext;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use const Jaeger\ZIPKIN_SPAN_FORMAT;
+use const OpenTracing\Formats\TEXT_MAP;
 
 class TracerTest extends TestCase
 {
     /**
-     * @var ReporterInterface
+     * @var ReporterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $reporter;
 
     /**
-     * @var SamplerInterface
+     * @var SamplerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $sampler;
 
@@ -34,7 +35,7 @@ class TracerTest extends TestCase
     private $logger;
 
     /**
-     * @var ScopeManager
+     * @var ScopeManager|\PHPUnit\Framework\MockObject\MockObject
      */
     private $scopeManager;
 
@@ -94,11 +95,23 @@ class TracerTest extends TestCase
         $this->tracer->inject($spanContext, ZIPKIN_SPAN_FORMAT, $carrier);
     }
 
-    function testExtractInvalidFormat()
+    /**
+     * @test
+     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
+     * @expectedExceptionMessage Unsupported format: bad-format
+     */
+    public function shouldThrowUnsupportedFormatExceptionOnExtractInvalidFormat()
     {
-        $this->expectException(UnsupportedFormat::class);
+        $this->tracer->extract('bad-format', []);
+    }
 
-        $spanContext = $this->tracer->extract("bad-format", []);
+    /** @test */
+    public function shouldExtractInformationFromCarrier()
+    {
+        $carrier = ['uber-trace-id' => '32834e4115071776:f7802330248418d:f123456789012345:1'];
+        $ctx = $this->tracer->extract(TEXT_MAP, $carrier);
+
+        $this->assertInstanceOf(SpanContext::class, $ctx);
     }
 
     function testGetScopeManager()

--- a/tests/Jaeger/TracerTest.php
+++ b/tests/Jaeger/TracerTest.php
@@ -95,23 +95,24 @@ class TracerTest extends TestCase
         $this->tracer->inject($spanContext, ZIPKIN_SPAN_FORMAT, $carrier);
     }
 
-    /**
-     * @test
-     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
-     * @expectedExceptionMessage Unsupported format: bad-format
-     */
-    public function shouldThrowUnsupportedFormatExceptionOnExtractInvalidFormat()
+    /** @test */
+    public function shouldNotThrowExceptionOnExtractInvalidFormat()
     {
-        $this->tracer->extract('bad-format', []);
+        $this->assertNull($this->tracer->extract('bad-format', []));
     }
 
     /** @test */
-    public function shouldExtractInformationFromCarrier()
+    public function shouldNotThrowExceptionOnExtractFromMalformedState()
+    {
+        $this->assertNull(null, $this->tracer->extract(TEXT_MAP, ['uber-trace-id' => '']));
+    }
+
+    /** @test */
+    public function shouldExtractSpanContextFromCarrier()
     {
         $carrier = ['uber-trace-id' => '32834e4115071776:f7802330248418d:f123456789012345:1'];
-        $ctx = $this->tracer->extract(TEXT_MAP, $carrier);
 
-        $this->assertInstanceOf(SpanContext::class, $ctx);
+        $this->assertInstanceOf(SpanContext::class, $this->tracer->extract(TEXT_MAP, $carrier));
     }
 
     function testGetScopeManager()


### PR DESCRIPTION
 All exceptions thrown from `Tracer::extract` should be caught and logged on WARN level so that business code execution isn't affected. If possible, catch implementation specific exceptions and log more meaningful information.