### PR TITLE
Reflect the "no exception" policy

### DIFF
--- a/src/Jaeger/Tracer.php
+++ b/src/Jaeger/Tracer.php
@@ -15,6 +15,7 @@ use OpenTracing\Tracer as OTTracer;
 use OpenTracing\SpanContext as OTSpanContext;
 use OpenTracing\Reference;
 use OpenTracing\StartSpanOptions;
+use OpenTracing\Exceptions\UnsupportedFormat;
 use const OpenTracing\Formats\BINARY;
 use const OpenTracing\Formats\HTTP_HEADERS;
 use const OpenTracing\Formats\TEXT_MAP;
@@ -217,6 +218,8 @@ class Tracer implements OTTracer
      * @param string $format
      * @param mixed $carrier
      * @return void
+     *
+     * @throws UnsupportedFormat
      */
     public function inject(OTSpanContext $spanContext, $format, &$carrier)
     {
@@ -224,8 +227,7 @@ class Tracer implements OTTracer
             $codec = $this->codecs[$format] ?? null;
 
             if ($codec == null) {
-                $this->logger->warning('Unsupported format: ' . $format);
-                return;
+                throw UnsupportedFormat::forFormat(is_scalar($format) ? $format : gettype($format));
             }
 
 
@@ -246,13 +248,15 @@ class Tracer implements OTTracer
      *
      * @param mixed $carrier
      * @return SpanContext|null
+     *
+     * @throws UnsupportedFormat
      */
     public function extract($format, $carrier)
     {
         $codec = $this->codecs[$format] ?? null;
 
         if ($codec == null) {
-            $this->logger->warning('Unsupported format: ' . $format);
+            throw UnsupportedFormat::forFormat(is_scalar($format) ? $format : gettype($format));
         }
 
         try {

--- a/tests/Jaeger/TracerTest.php
+++ b/tests/Jaeger/TracerTest.php
@@ -85,6 +85,20 @@ class TracerTest extends TestCase
         $this->assertEquals('test-operation1', $tracer->getActiveSpan()->getOperationName());
    }
 
+    /**
+     * @test
+     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
+     * @expectedExceptionMessage The format 'bad-format' is not supported.
+     */
+    public function shouldThrowExceptionOnInvalidFormat()
+    {
+        $spanContext = new SpanContext(0, 0, 0, 0);
+        $carrier = [];
+
+        $this->tracer->inject($spanContext, 'bad-format', $carrier);
+        $this->assertSame([], $carrier);
+    }
+
     /** @test */
     public function shouldNotThrowExceptionOnInvalidContext()
     {
@@ -92,16 +106,6 @@ class TracerTest extends TestCase
         $carrier = [];
 
         $this->tracer->inject($spanContext, ZIPKIN_SPAN_FORMAT, $carrier);
-        $this->assertSame([], $carrier);
-    }
-
-    /** @test */
-    public function shouldNotThrowExceptionOnInvalidFormat()
-    {
-        $spanContext = new SpanContext(0, 0, 0, 0);
-        $carrier = [];
-
-        $this->tracer->inject($spanContext, null, $carrier);
         $this->assertSame([], $carrier);
     }
 
@@ -117,8 +121,12 @@ class TracerTest extends TestCase
         $this->assertEquals('0:0:0:0', $carrier[TRACE_ID_HEADER]);
     }
 
-    /** @test */
-    public function shouldNotThrowExceptionOnExtractInvalidFormat()
+    /**
+     * @test
+     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
+     * @expectedExceptionMessage The format 'bad-format' is not supported.
+     */
+    public function shouldThrowExceptionOnExtractInvalidFormat()
     {
         $this->assertNull($this->tracer->extract('bad-format', []));
     }


### PR DESCRIPTION
More exact match the "no exception" policy for `Tracer::extract` and `Tracer::inject`.