### PR TITLE
REM [php] Remove support for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 language: php
 
 php:
-  - '5.6'
   - '7.0'
   - '7.1'
   - '7.2'
@@ -16,7 +15,6 @@ git:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: '5.6'
     - php: nightly
 
 install:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use OpenTracing\GlobalTracer;
 $config = new Config(
     [
         'sampler' => [
-            'type' => 'const', 
+            'type' => 'const',
             'param' => true,
         ],
         'logging' => true,
@@ -55,7 +55,6 @@ Tests are located in the `tests` directory. See [tests/README.md](./tests/README
 ## Roadmap
 
 - [Support Span baggage](https://github.com/jonahgeorge/jaeger-client-php/issues/5)
-- [Support PHP Version 5.6](https://github.com/jonahgeorge/jaeger-client-php/issues/11)
 - [Support Tracer metrics](https://github.com/jonahgeorge/jaeger-client-php/issues/12)
 - [Support Tracer error reporting](https://github.com/jonahgeorge/jaeger-client-php/issues/13)
 
@@ -63,7 +62,7 @@ Tests are located in the `tests` directory. See [tests/README.md](./tests/README
 
 [MIT License](./LICENSE).
 
-[ci-img]: https://travis-ci.org/jonahgeorge/jaeger-client-php.svg?branch=travis  
+[ci-img]: https://travis-ci.org/jonahgeorge/jaeger-client-php.svg?branch=travis
 [ci]: https://travis-ci.org/jonahgeorge/jaeger-client-php
 [packagist-img]: https://badge.fury.io/ph/jonahgeorge%2Fjaeger-client-php.svg
 [packagist]: https://badge.fury.io/ph/jonahgeorge%2Fjaeger-client-php

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "ext-sockets": "*",
         "opentracing/opentracing": "1.0.0-beta5",
         "packaged/thrift": "^0.10",
@@ -34,7 +34,7 @@
         "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.6 || ^6.4",
+        "phpunit/phpunit": "^6.4",
         "squizlabs/php_codesniffer": "3.*"
     },
     "config": {

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,6 @@ This folder includes all the unit tests that test Jaeger components, ensuring th
 
 | version | status |
 |---------|--------|
-| 5.6     | 𝙓      |
 | 7.0     | ✔      |
 | 7.1     | ✔      |
 | 7.2     | ✔      |
@@ -40,7 +39,6 @@ There is also an ability to run tests for different PHP versions. To achieve thi
 [docker](https://docs.docker.com/install/)-based approach:
 
 ```bash
-$ docker run --rm -it -v $(pwd):/usr/app php:5.6 ./usr/app/tests/php-test.sh
 
 $ docker run --rm -it -v $(pwd):/usr/app php:7.0 ./usr/app/tests/php-test.sh
 


### PR DESCRIPTION
Library is using return type declarations which are supported only from
PHP version 7.

---

refs: https://github.com/jonahgeorge/jaeger-client-php/issues/11