### PR TITLE
Decrease log level to debug

### DIFF
--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -105,7 +105,7 @@ class Config
     private function initializeGlobalTracer(Tracer $tracer)
     {
         GlobalTracer::set($tracer);
-        $this->logger->info('OpenTracing\GlobalTracer initialized to ' . $tracer->getServiceName());
+        $this->logger->debug('OpenTracing\GlobalTracer initialized to ' . $tracer->getServiceName());
     }
 
     /**
@@ -173,7 +173,7 @@ class Config
         $protocol = new TCompactProtocol($transport);
         $client = new AgentClient($protocol);
 
-        $this->logger->info('Initializing Jaeger Tracer with UDP reporter');
+        $this->logger->debug('Initializing Jaeger Tracer with UDP reporter');
 
         return new UdpSender($client, $this->getMaxBufferLength(), $this->logger);
     }

--- a/src/Jaeger/Reporter/LoggingReporter.php
+++ b/src/Jaeger/Reporter/LoggingReporter.php
@@ -34,7 +34,7 @@ class LoggingReporter implements ReporterInterface
      */
     public function reportSpan(Span $span)
     {
-        $this->logger->info('Reporting span ' . $span->getOperationName());
+        $this->logger->debug('Reporting span ' . $span->getOperationName());
     }
 
     /**

--- a/tests/Jaeger/Reporter/LoggingReporterTest.php
+++ b/tests/Jaeger/Reporter/LoggingReporterTest.php
@@ -22,7 +22,7 @@ class LoggingReporterTest extends TestCase
         $reporter = new LoggingReporter($logger);
 
         $logger->expects($this->once())
-            ->method('info')
+            ->method('debug')
             ->with($this->stringStartsWith('Reporting span'));
 
         $reporter->reportSpan($span);


### PR DESCRIPTION
As far as jaeger client usually produces a lot of logs (ex. on init), it could be convenient to isolate this information at debug level