### PR TITLE
Add support for RateLimitingSampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ $config = new Config(
     [
         'sampler' => [
             'type' => Jaeger\SAMPLER_TYPE_CONST,
-            'params' => [
-                'sample' => true
-            ],
+            'param' => true,
         ],
         'logging' => true,
     ],
@@ -52,35 +50,48 @@ $tracer->flush();
 
 ### Samplers
 
-#### Const sampler `Jaeger\SAMPLER_TYPE_CONST`
+List of supported samplers, for more info about samplers, please read [Jaeger Sampling](https://www.jaegertracing.io/docs/1.9/sampling/) guide.
+
+#### Const sampler
 This sampler either samples everything, or nothing.
 
-##### Parameters
+##### Configuration
 ```
-'sample' => true|false // boolean
+'sampler' => [
+    'type' => Jaeger\SAMPLER_TYPE_CONST,
+    'param' => true, // boolean wheter to trace or not
+],
 ```
 
-#### Probabilistic sampler `Jaeger\SAMPLER_TYPE_PROBABILISTIC`
+#### Probabilistic sampler
 This sampler samples request by given rate.
 
-##### Parameters
+##### Configuration
 ```
-'rate' => 0.0 - 1.0 // float
+'sampler' => [
+    'type' => Jaeger\SAMPLER_TYPE_PROBABILISTIC,
+    'param' => 0.5, // float [0.0, 1.0]
+],
 ```
 
-#### Rate limiting sampler `Jaeger\SAMPLER_TYPE_RATE_LIMITING`
-Samples maximum specified number of traces per second.
+#### Rate limiting sampler
+Samples maximum specified number of traces (requests) per second.
 
 ##### Requirements
 * `psr/cache` PSR-6 cache component to store and retrieve sampler state between requests.
 Cache component is passed to `Jaeger\Config` trough its constructor.
 * `hrtime()` function, that can retrieve time in nanoseconds. You need either `php 7.3` or [PECL/hrtime](http://pecl.php.net/package/hrtime) extension.
 
-##### Parameters
+##### Configuration
 ```
-'maxTracesPerSecond' => 100 // integer
-'currentBalanceKey' => 'rate.currentBalance' // string
-'lastTickKey' => 'rate.lastTick' // string
+'sampler' => [
+    'type' => Jaeger\SAMPLER_TYPE_RATE_LIMITING,
+    'param' => 100 // integer maximum number of traces per second,
+    'cache' => [
+        'currentBalanceKey' => 'rate.currentBalance' // string
+        'lastTickKey' => 'rate.lastTick' // string
+    ]
+],
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ use OpenTracing\GlobalTracer;
 $config = new Config(
     [
         'sampler' => [
-            'type' => 'const',
-            'param' => true,
+            'type' => Jaeger\SAMPLER_TYPE_CONST,
+            'params' => [
+                'sample' => true
+            ],
         ],
         'logging' => true,
     ],
@@ -46,6 +48,39 @@ $scope = $tracer->startActiveSpan('TestSpan', []);
 $scope->close();
 
 $tracer->flush();
+```
+
+### Samplers
+
+#### Const sampler `Jaeger\SAMPLER_TYPE_CONST`
+This sampler either samples everything, or nothing.
+
+##### Parameters
+```
+'sample' => true|false // boolean
+```
+
+#### Probabilistic sampler `Jaeger\SAMPLER_TYPE_PROBABILISTIC`
+This sampler samples request by given rate.
+
+##### Parameters
+```
+'rate' => 0.0 - 1.0 // float
+```
+
+#### Rate limiting sampler `Jaeger\SAMPLER_TYPE_RATE_LIMITING`
+Samples maximum specified number of traces per second.
+
+##### Requirements
+* `psr/cache` PSR-6 cache component to store and retrieve sampler state between requests.
+Cache component is passed to `Jaeger\Config` trough its constructor.
+* `hrtime()` function, that can retrieve time in nanoseconds. You need either `php 7.3` or [PECL/hrtime](http://pecl.php.net/package/hrtime) extension.
+
+##### Parameters
+```
+'maxTracesPerSecond' => 100 // integer
+'currentBalanceKey' => 'rate.currentBalance' // string
+'lastTickKey' => 'rate.lastTick' // string
 ```
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,17 @@
         "opentracing/opentracing": "1.0.0-beta5",
         "packaged/thrift": "^0.10",
         "phlib/base_convert": "^1.0",
-        "psr/log": "^1.0"
+        "psr/cache": "^1.0",
+        "psr/log": "^1.0",
+        "symfony/polyfill-php73": "^1.10"
     },
     "provide": {
         "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*",
+        "cache/array-adapter": "^1.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "packaged/thrift": "^0.10",
         "phlib/base_convert": "^1.0",
         "psr/cache": "^1.0",
-        "psr/log": "^1.0",
-        "symfony/polyfill-php73": "^1.10"
+        "psr/log": "^1.0"
     },
     "provide": {
         "opentracing/opentracing": "1.0.0-beta5"
@@ -38,7 +37,8 @@
     "require-dev": {
         "phpunit/phpunit": "^6.4",
         "squizlabs/php_codesniffer": "3.*",
-        "cache/array-adapter": "^1.0"
+        "cache/array-adapter": "^1.0",
+        "symfony/polyfill-php73": "^1.10"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/Jaeger/Codec/TextCodec.php
+++ b/src/Jaeger/Codec/TextCodec.php
@@ -130,7 +130,7 @@ class TextCodec implements CodecInterface
             return null;
         }
 
-        return new SpanContext($traceId, $spanId, $parentId, $flags);
+        return new SpanContext($traceId, $spanId, $parentId, $flags, $baggage);
     }
 
     /**

--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -88,7 +88,17 @@ class Config
      */
     public function createTracer(ReporterInterface $reporter, SamplerInterface $sampler): Tracer
     {
-        return new Tracer($this->serviceName, $reporter, $sampler, true, $this->logger);
+        return new Tracer(
+            $this->serviceName,
+            $reporter,
+            $sampler,
+            true,
+            $this->logger,
+            null,
+            $this->getTraceIdHeader(),
+            $this->getBaggageHeaderPrefix(),
+            $this->getDebugIdHeaderKey()
+        );
     }
 
     /**
@@ -210,5 +220,29 @@ class Config
     private function getLocalAgentGroup(): array
     {
         return $this->config['local_agent'] ?? [];
+    }
+
+    /**
+     * @return string
+     */
+    private function getTraceIdHeader(): string
+    {
+        return $this->config['trace_id_header'] ?? TRACE_ID_HEADER;
+    }
+
+    /**
+     * @return string
+     */
+    private function getBaggageHeaderPrefix(): string
+    {
+        return $this->config['baggage_header_prefix'] ?? BAGGAGE_HEADER_PREFIX;
+    }
+
+    /**
+     * @return string
+     */
+    private function getDebugIdHeaderKey(): string
+    {
+        return $this->config['debug_id_header_key'] ?? DEBUG_ID_HEADER_KEY;
     }
 }

--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -9,10 +9,13 @@ use Jaeger\Reporter\RemoteReporter;
 use Jaeger\Reporter\ReporterInterface;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Sampler\ProbabilisticSampler;
+use Jaeger\Sampler\RateLimitingSampler;
 use Jaeger\Sampler\SamplerInterface;
 use Jaeger\Sender\UdpSender;
 use Jaeger\Thrift\Agent\AgentClient;
+use Jaeger\Util\RateLimiter;
 use OpenTracing\GlobalTracer;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Thrift\Exception\TTransportException;
@@ -42,14 +45,24 @@ class Config
     private $logger;
 
     /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
      * Config constructor.
      * @param array $config
      * @param string|null $serviceName
      * @param LoggerInterface|null $logger
+     * @param CacheItemPoolInterface|null $cache
      * @throws Exception
      */
-    public function __construct(array $config, string $serviceName = null, LoggerInterface $logger = null)
-    {
+    public function __construct(
+        array $config,
+        string $serviceName = null,
+        LoggerInterface $logger = null,
+        CacheItemPoolInterface $cache = null
+    ) {
         $this->config = $config;
 
         $this->serviceName = $config['service_name'] ?? $serviceName;
@@ -58,6 +71,7 @@ class Config
         }
 
         $this->logger = $logger ?: new NullLogger();
+        $this->cache = $cache;
     }
 
     /**
@@ -149,14 +163,23 @@ class Config
     {
         $samplerConfig = $this->config['sampler'] ?? [];
         $samplerType = $samplerConfig['type'] ?? null;
-        $samplerParam = $samplerConfig['param'] ?? null;
+        $samplerParams = $samplerConfig['params'] ?? [];
 
         if ($samplerType === null) {
             return new ConstSampler(true);
         } elseif ($samplerType === SAMPLER_TYPE_CONST) {
-            return new ConstSampler($samplerParam ?? false);
+            return new ConstSampler($samplerParams['sample'] ?? false);
         } elseif ($samplerType === SAMPLER_TYPE_PROBABILISTIC) {
-            return new ProbabilisticSampler((float)$samplerParam);
+            return new ProbabilisticSampler((float)$samplerParams['rate'] ?? 0.0);
+        } elseif ($samplerType === SAMPLER_TYPE_RATE_LIMITING) {
+            return new RateLimitingSampler(
+                $samplerParams['maxTracesPerSecond'] ?? 0,
+                new RateLimiter(
+                    $this->cache,
+                    $samplerParams['currentBalanceKey'] ?? 'rate.currentBalance',
+                    $samplerParams['lastTickKey'] ?? 'rate.lastTick'
+                )
+            );
         }
 
         throw new Exception('Unknown sampler type ' . $samplerType);

--- a/src/Jaeger/Sampler/RateLimitingSampler.php
+++ b/src/Jaeger/Sampler/RateLimitingSampler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Jaeger\Sampler;
+
+use Jaeger\Util\RateLimiter;
+
+use const Jaeger\SAMPLER_PARAM_TAG_KEY;
+use const Jaeger\SAMPLER_TYPE_RATE_LIMITING;
+use const Jaeger\SAMPLER_TYPE_TAG_KEY;
+
+class RateLimitingSampler implements SamplerInterface
+{
+    /**
+     * @var RateLimiter
+     */
+    private $rateLimiter;
+
+    /**
+     * A list of the sampler tags.
+     *
+     * @var array
+     */
+    private $tags = [];
+
+    public function __construct($maxTracesPerSecond, RateLimiter $rateLimiter)
+    {
+        $this->tags = [
+            SAMPLER_TYPE_TAG_KEY => SAMPLER_TYPE_RATE_LIMITING,
+            SAMPLER_PARAM_TAG_KEY => $maxTracesPerSecond,
+        ];
+
+        $maxTracesPerNanosecond = $maxTracesPerSecond / 1000000000.0;
+        $this->rateLimiter = $rateLimiter;
+        $this->rateLimiter->setCreditsPerNanosecond($maxTracesPerNanosecond);
+        $this->rateLimiter->setMaxBalance($maxTracesPerSecond > 1.0 ? 1.0 : $maxTracesPerSecond);
+    }
+
+    /**
+     * Whether or not the new trace should be sampled.
+     *
+     * Implementations should return an array in the format [$decision, $tags].
+     *
+     * @param string $traceId The traceId on the span.
+     * @param string $operation The operation name set on the span.
+     * @return array
+     */
+    public function isSampled(string $traceId = '', string $operation = '')
+    {
+        return [$this->rateLimiter->checkCredit(1.0), $this->tags];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Only implemented to satisfy the sampler interface.
+     *
+     * @return void
+     */
+    public function close()
+    {
+        // nothing to do
+    }
+}

--- a/src/Jaeger/Sampler/RateLimitingSampler.php
+++ b/src/Jaeger/Sampler/RateLimitingSampler.php
@@ -31,8 +31,7 @@ class RateLimitingSampler implements SamplerInterface
 
         $maxTracesPerNanosecond = $maxTracesPerSecond / 1000000000.0;
         $this->rateLimiter = $rateLimiter;
-        $this->rateLimiter->setCreditsPerNanosecond($maxTracesPerNanosecond);
-        $this->rateLimiter->setMaxBalance($maxTracesPerSecond > 1.0 ? 1.0 : $maxTracesPerSecond);
+        $this->rateLimiter->initialize($maxTracesPerNanosecond, $maxTracesPerSecond > 1.0 ? 1.0 : $maxTracesPerSecond);
     }
 
     /**

--- a/src/Jaeger/Tracer.php
+++ b/src/Jaeger/Tracer.php
@@ -273,6 +273,7 @@ class Tracer implements OTTracer
      */
     public function flush()
     {
+        $this->sampler->close();
         $this->reporter->close();
     }
 

--- a/src/Jaeger/Util/RateLimiter.php
+++ b/src/Jaeger/Util/RateLimiter.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Jaeger\Util;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+class RateLimiter
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @var float
+     */
+    private $balance;
+
+    /**
+     * @var integer
+     */
+    private $lastTick;
+
+    /**
+     * @var int
+     */
+    private $creditsPerNanosecond = 0;
+
+    /**
+     * @var float
+     */
+    private $maxBalance = 0;
+
+    public function __construct(
+        CacheItemPoolInterface $cache,
+        string $currentBalanceKey,
+        string $lastTickKey
+    ) {
+        $this->cache = $cache;
+        $this->balance = $this->cache->getItem($currentBalanceKey);
+        $this->lastTick = $this->cache->getItem($lastTickKey);
+    }
+
+    /**
+     * @param $itemCost
+     * @return bool
+     */
+    public function checkCredit($itemCost)
+    {
+        if (!$this->creditsPerNanosecond) {
+            return false;
+        }
+
+        list($lastTick, $balance) = $this->getState();
+
+        if (!$lastTick) {
+            $this->saveState(hrtime(true), 0);
+            return true;
+        }
+
+        $currentTime = hrtime(true);
+        $elapsedTime = $currentTime - $lastTick;
+        $balance += $elapsedTime * $this->creditsPerNanosecond;
+
+        if ($balance > $this->maxBalance) {
+            $balance = $this->maxBalance;
+        }
+
+        $result = false;
+        if ($balance >= $itemCost) {
+            $balance -= $itemCost;
+            $result = true;
+        }
+
+        $this->saveState($currentTime, $balance);
+
+        return $result;
+    }
+
+    /**
+     * @param int $creditsPerNanosecond
+     */
+    public function setCreditsPerNanosecond($creditsPerNanosecond)
+    {
+        $this->creditsPerNanosecond = $creditsPerNanosecond;
+    }
+
+    /**
+     * @param float $maxBalance
+     */
+    public function setMaxBalance(float $maxBalance)
+    {
+        $this->maxBalance = $maxBalance;
+    }
+
+    private function getState()
+    {
+        return [
+            $this->lastTick->get(),
+            $this->balance->get()
+        ];
+    }
+
+    private function saveState($lastTick, $balance)
+    {
+        $this->lastTick->set($lastTick);
+        $this->balance->set($balance);
+        $this->cache->saveDeferred($this->lastTick);
+        $this->cache->saveDeferred($this->balance);
+        $this->cache->commit();
+    }
+}

--- a/src/Jaeger/Util/RateLimiter.php
+++ b/src/Jaeger/Util/RateLimiter.php
@@ -93,7 +93,7 @@ class RateLimiter
      * @param float $creditsPerNanosecond
      * @param float $maxBalance
      */
-    public function initialize(float $creditsPerNanosecond, float $maxBalance) : void
+    public function initialize(float $creditsPerNanosecond, float $maxBalance)
     {
         $this->creditsPerNanosecond = $creditsPerNanosecond;
         $this->maxBalance = $maxBalance;

--- a/src/Jaeger/Util/RateLimiter.php
+++ b/src/Jaeger/Util/RateLimiter.php
@@ -70,7 +70,6 @@ class RateLimiter
         $currentTick = hrtime(true);
         $elapsedTime = $currentTick - $lastTick;
         $balance += $elapsedTime * $this->creditsPerNanosecond;
-        var_dump($lastTick, $currentTick, $elapsedTime, $balance, $this->creditsPerNanosecond);
         if ($balance > $this->maxBalance) {
             $balance = $this->maxBalance;
         }

--- a/src/Jaeger/Util/RateLimiter.php
+++ b/src/Jaeger/Util/RateLimiter.php
@@ -67,10 +67,10 @@ class RateLimiter
             return true;
         }
 
-        $currentTime = hrtime(true);
-        $elapsedTime = $currentTime - $lastTick;
+        $currentTick = hrtime(true);
+        $elapsedTime = $currentTick - $lastTick;
         $balance += $elapsedTime * $this->creditsPerNanosecond;
-
+        var_dump($lastTick, $currentTick, $elapsedTime, $balance, $this->creditsPerNanosecond);
         if ($balance > $this->maxBalance) {
             $balance = $this->maxBalance;
         }
@@ -81,7 +81,7 @@ class RateLimiter
             $result = true;
         }
 
-        $this->saveState($currentTime, $balance);
+        $this->saveState($currentTick, $balance);
 
         return $result;
     }

--- a/tests/Jaeger/Codec/TextCodecTest.php
+++ b/tests/Jaeger/Codec/TextCodecTest.php
@@ -2,8 +2,11 @@
 
 namespace Jaeger\Tests\Codec;
 
+use const Jaeger\BAGGAGE_HEADER_PREFIX;
 use Jaeger\Codec\TextCodec;
+use const Jaeger\DEBUG_ID_HEADER_KEY;
 use Jaeger\SpanContext;
+use const Jaeger\TRACE_ID_HEADER;
 use PHPUnit\Framework\TestCase;
 
 class TextCodecTest extends TestCase
@@ -11,34 +14,128 @@ class TextCodecTest extends TestCase
     /** @var TextCodec */
     private $textCodec;
 
-    /** @var SpanContext */
-    private $ctx;
-
     public function setUp()
     {
-        $this->ctx = new SpanContext('trace-id', 'span-id', null, null);
         $this->textCodec = new TextCodec();
     }
 
-    public function testCanInjectContextInCarrier()
+    public function testCanInjectSimpleContextInCarrier()
+    {
+        $context = new SpanContext('trace-id', 'span-id', null, null);
+        $carrier = [];
+
+        $this->textCodec->inject($context, $carrier);
+
+        $this->assertCount(1 , $carrier);
+        $this->assertArrayHasKey(TRACE_ID_HEADER, $carrier);
+    }
+
+    /**
+     * @dataProvider contextDataProvider
+     * @param bool $urlEncode
+     * @param $baggage
+     */
+    public function testCanInjectContextBaggageInCarrier(bool $urlEncode, $baggage, $injectedBaggage)
     {
         $carrier = [];
 
-        $this->textCodec->inject($this->ctx, $carrier);
+        $context = new SpanContext('trace-id', 'span-id', null, null, $baggage);
+        $textCodec = new TextCodec($urlEncode);
+        $textCodec->inject($context, $carrier);
 
-        $this->assertFalse(empty($carrier));
+        $this->assertCount(1 + count($baggage) , $carrier);
+        $this->assertArrayHasKey(TRACE_ID_HEADER, $carrier);
+        foreach ($injectedBaggage as $key => $value) {
+            $this->assertArrayHasKey(BAGGAGE_HEADER_PREFIX . $key, $carrier);
+            $this->assertEquals($carrier[BAGGAGE_HEADER_PREFIX . $key], $value);
+        }
     }
 
-    public function testSpanContextParsingFromHeader()
+    public function contextDataProvider()
     {
-        $carrier = ['uber-trace-id' => '32834e4115071776:f7802330248418d:f123456789012345:1'];
+        return [
+            [false, ['baggage-1' => 'baggage value'], ['baggage-1' => 'baggage value']],
+            [false, ['baggage-1' => 'https://testdomain.sk'], ['baggage-1' => 'https://testdomain.sk']],
+            [true, ['baggage-1' => 'https://testdomain.sk'], ['baggage-1' => 'https%3A%2F%2Ftestdomain.sk']],
+        ];
+    }
 
-        $spanContext = $this->textCodec->extract($carrier);
+    /**
+     * @dataProvider carrierDataProvider
+     * @param $urlEncode
+     * @param $carrier
+     * @param $traceId
+     * @param $spanId
+     * @param $parentId
+     * @param $flags
+     * @param $baggage
+     * @throws \Exception
+     */
+    public function testSpanContextParsingFromHeader($urlEncode, $carrier, $traceId, $spanId, $parentId, $flags, $baggage)
+    {
+        $textCodec = new TextCodec($urlEncode);
+        $spanContext = $textCodec->extract($carrier);
 
-        self::assertEquals("3639838965278119798", $spanContext->getTraceId());
-        self::assertEquals("1114643325879075213", $spanContext->getSpanId());
-        self::assertEquals("-1070935975401544891", $spanContext->getParentId());
-        self::assertEquals(1, $spanContext->getFlags());
+        $this->assertEquals($traceId, $spanContext->getTraceId());
+        $this->assertEquals($spanId, $spanContext->getSpanId());
+        $this->assertEquals($parentId, $spanContext->getParentId());
+        $this->assertEquals($flags, $spanContext->getFlags());
+        $this->assertEquals(count($baggage), count($spanContext->getBaggage()));
+        foreach ($baggage as $key => $value) {
+            $this->assertEquals($value, $spanContext->getBaggageItem($key));
+        }
+    }
+
+    public function carrierDataProvider()
+    {
+        return [
+            [
+                false,
+                [
+                    TRACE_ID_HEADER => '32834e4115071776:f7802330248418d:f123456789012345:1'
+                ],
+                "3639838965278119798",
+                "1114643325879075213",
+                "-1070935975401544891",
+                1,
+                []
+            ],
+            [
+                false,
+                [
+                    TRACE_ID_HEADER => '32834e4115071776:f7802330248418d:f123456789012345:1',
+                    BAGGAGE_HEADER_PREFIX . 'baggage-1' => 'https://testdomain.sk',
+                ],
+                "3639838965278119798",
+                "1114643325879075213",
+                "-1070935975401544891",
+                1,
+                ['baggage-1' => 'https://testdomain.sk']
+            ],
+            [
+                true,
+                [
+                    TRACE_ID_HEADER => '32834e4115071776:f7802330248418d:f123456789012345:1',
+                    BAGGAGE_HEADER_PREFIX . 'baggage-1' => 'https%3A%2F%2Ftestdomain.sk',
+                ],
+                "3639838965278119798",
+                "1114643325879075213",
+                "-1070935975401544891",
+                1,
+                ['baggage-1' => 'https://testdomain.sk']
+            ]
+        ];
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage baggage without trace ctx
+     */
+    public function testBaggageWithoutTraceContext()
+    {
+        $carrier = [BAGGAGE_HEADER_PREFIX.'test' => 'some data'];
+
+        $this->textCodec->extract($carrier);
     }
 
     /**
@@ -47,8 +144,28 @@ class TextCodecTest extends TestCase
      */
     public function testInvalidSpanContextParsingFromHeader()
     {
-        $carrier = ['uber-trace-id' => 'invalid_data'];
+        $carrier = [TRACE_ID_HEADER => 'invalid_data'];
 
         $this->textCodec->extract($carrier);
+    }
+
+    public function testExtractDebugSpanContext()
+    {
+        $carrier = [DEBUG_ID_HEADER_KEY => 'debugId'];
+
+        $spanContext = $this->textCodec->extract($carrier);
+
+        $this->assertEquals('debugId', $spanContext->getDebugId());
+        $this->assertNull($spanContext->getTraceId());
+        $this->assertNull($spanContext->getSpanId());
+        $this->assertNull($spanContext->getParentId());
+        $this->assertNull($spanContext->getFlags());
+    }
+
+
+    public function testExtractEmptySpanContext()
+    {
+        $spanContext = $this->textCodec->extract([]);
+        $this->assertNull($spanContext);
     }
 }

--- a/tests/Jaeger/Codec/TextCodecTest.php
+++ b/tests/Jaeger/Codec/TextCodecTest.php
@@ -80,7 +80,7 @@ class TextCodecTest extends TestCase
         $this->assertEquals($spanId, $spanContext->getSpanId());
         $this->assertEquals($parentId, $spanContext->getParentId());
         $this->assertEquals($flags, $spanContext->getFlags());
-        $this->assertEquals(count($baggage), count($spanContext->getBaggage()));
+        $this->assertCount(count($baggage), $spanContext->getBaggage() ? $spanContext->getBaggage() : []);
         foreach ($baggage as $key => $value) {
             $this->assertEquals($value, $spanContext->getBaggageItem($key));
         }

--- a/tests/Jaeger/ConfigTest.php
+++ b/tests/Jaeger/ConfigTest.php
@@ -80,4 +80,31 @@ class ConfigTest extends TestCase
         $tracer = GlobalTracer::get();
         $this->assertInstanceOf(Tracer::class, $tracer);
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage Unknown sampler type unsupportedSampler
+     */
+    public function shouldThrowExceptionWhenCreatingNotSupportedSampler()
+    {
+        $config = new Config(['service_name' => 'test-service-name', 'sampler' => ['type' => 'unsupportedSampler']]);
+
+        $config->initializeTracer();
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage You cannot use RateLimitingSampler without cache component
+     */
+    public function shouldThrowExceptionWhenCreatingRateLimitingSamplerWithoutCacheComponent()
+    {
+        $config = new Config([
+            'service_name' => 'test-service-name',
+            'sampler' => ['type' => \Jaeger\SAMPLER_TYPE_RATE_LIMITING]]
+        );
+
+        $config->initializeTracer();
+    }
 }

--- a/tests/Jaeger/Sampler/RateLimitSamplerTest.php
+++ b/tests/Jaeger/Sampler/RateLimitSamplerTest.php
@@ -17,6 +17,7 @@ class RateLimitSamplerTest extends TestCase
      * @dataProvider maxRateProvider
      * @param integer $maxTracesPerSecond
      * @param array $traces array of traces result after being sampled one after another
+     * @throws
      */
     public function shouldDetermineWhetherOrTraceShouldBeSampled($maxTracesPerSecond, $traces)
     {

--- a/tests/Jaeger/Sampler/RateLimitSamplerTest.php
+++ b/tests/Jaeger/Sampler/RateLimitSamplerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Jaeger\Test\Sampler;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Jaeger\Sampler\RateLimitingSampler;
+use Jaeger\Util\RateLimiter;
+use PHPUnit\Framework\TestCase;
+use const Jaeger\SAMPLER_PARAM_TAG_KEY;
+use const Jaeger\SAMPLER_TYPE_RATE_LIMITING;
+use const Jaeger\SAMPLER_TYPE_TAG_KEY;
+
+class RateLimitSamplerTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider maxRateProvider
+     * @param integer $maxTracesPerSecond
+     * @param array $traces array of traces result after being sampled one after another
+     */
+    public function shouldDetermineWhetherOrTraceShouldBeSampled($maxTracesPerSecond, $traces)
+    {
+        $sampler = new RateLimitingSampler(
+            $maxTracesPerSecond,
+            new RateLimiter(new ArrayCachePool(), 'balance', 'lastTick')
+        );
+
+        $sampler->isSampled();
+        foreach ($traces as $trace) {
+            list($sleep, $decision) = $trace;
+            usleep($sleep);
+            list($sampled, $tags) = $sampler->isSampled();
+            $this->assertEquals($decision, $sampled);
+            $this->assertEquals([
+                SAMPLER_TYPE_TAG_KEY  => SAMPLER_TYPE_RATE_LIMITING,
+                SAMPLER_PARAM_TAG_KEY => $maxTracesPerSecond,
+            ], $tags);
+        }
+
+        $sampler->close();
+    }
+
+    public function maxRateProvider()
+    {
+        return [
+            [1000000, [[1, true], [1, true], [1, true]]],
+            [1000, [[1000, true], [0, false], [1000, true]]],
+            [0, [0, false]],
+        ];
+    }
+}

--- a/tests/Jaeger/Sampler/RateLimitSamplerTest.php
+++ b/tests/Jaeger/Sampler/RateLimitSamplerTest.php
@@ -45,7 +45,7 @@ class RateLimitSamplerTest extends TestCase
     {
         return [
             [1000000, [[1, true], [1, true], [1, true]]],
-            [1000, [[0, false], [1, false], [1000, true]]],
+            [1000, [[0, false], [1000, true]]],
             [0, [0, false]],
         ];
     }

--- a/tests/Jaeger/Sampler/RateLimitSamplerTest.php
+++ b/tests/Jaeger/Sampler/RateLimitSamplerTest.php
@@ -45,7 +45,7 @@ class RateLimitSamplerTest extends TestCase
     {
         return [
             [1000000, [[1, true], [1, true], [1, true]]],
-            [1000, [[1000, true], [0, false], [1000, true]]],
+            [1000, [[0, false], [1, false], [1000, true]]],
             [0, [0, false]],
         ];
     }

--- a/tests/Jaeger/Sampler/RateLimitSamplerTest.php
+++ b/tests/Jaeger/Sampler/RateLimitSamplerTest.php
@@ -16,10 +16,10 @@ class RateLimitSamplerTest extends TestCase
      * @test
      * @dataProvider maxRateProvider
      * @param integer $maxTracesPerSecond
-     * @param array $traces array of traces result after being sampled one after another
+     * @param bool $decision
      * @throws
      */
-    public function shouldDetermineWhetherOrTraceShouldBeSampled($maxTracesPerSecond, $traces)
+    public function shouldDetermineWhetherOrTraceShouldBeSampled($maxTracesPerSecond, $decision)
     {
         $sampler = new RateLimitingSampler(
             $maxTracesPerSecond,
@@ -27,16 +27,12 @@ class RateLimitSamplerTest extends TestCase
         );
 
         $sampler->isSampled();
-        foreach ($traces as $trace) {
-            list($sleep, $decision) = $trace;
-            usleep($sleep);
-            list($sampled, $tags) = $sampler->isSampled();
-            $this->assertEquals($decision, $sampled);
-            $this->assertEquals([
-                SAMPLER_TYPE_TAG_KEY  => SAMPLER_TYPE_RATE_LIMITING,
-                SAMPLER_PARAM_TAG_KEY => $maxTracesPerSecond,
-            ], $tags);
-        }
+        list($sampled, $tags) = $sampler->isSampled();
+        $this->assertEquals($decision, $sampled);
+        $this->assertEquals([
+            SAMPLER_TYPE_TAG_KEY  => SAMPLER_TYPE_RATE_LIMITING,
+            SAMPLER_PARAM_TAG_KEY => $maxTracesPerSecond,
+        ], $tags);
 
         $sampler->close();
     }
@@ -44,9 +40,9 @@ class RateLimitSamplerTest extends TestCase
     public function maxRateProvider()
     {
         return [
-            [1000000, [[1, true], [1, true], [1, true]]],
-            [1000, [[0, false], [1000, true]]],
-            [0, [0, false]],
+            [1000000, true],
+            [1, false],
+            [0, false],
         ];
     }
 }

--- a/tests/php-test.sh
+++ b/tests/php-test.sh
@@ -24,6 +24,8 @@ apt-get install -yq git wget unzip zip > /dev/null 2>&1
 
 echo "[INFO]: Install PHP extensions..."
 docker-php-ext-install bcmath sockets > /dev/null 2>&1
+pecl install hrtime > /dev/null 2>&1
+docker-php-ext-enable hrtime > /dev/null 2>&1
 
 echo "[INFO]: Install Xdebug to enable code coverage..."
 pecl install xdebug > /dev/null 2>&1


### PR DESCRIPTION
Should implement #7 

Because we need to store `RateLimiter` state between requests, I decided, to use [PSR-6 Cache](https://www.php-fig.org/psr/psr-6/) , that should be passed to `RateLimiter` trough dependency injection.

Any more appropriate ways, how may I store data between requests are welcome.

In case of any issues or questions, please, do ask :)