### PR TITLE
Fix #75 unsupported operand error when using baggage

### DIFF
--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -38,7 +38,7 @@ class SpanContext implements OTSpanContext
         $this->spanId = $spanId;
         $this->parentId = $parentId;
         $this->flags = $flags;
-        $this->baggage = $baggage;
+        $this->baggage = is_array($baggage) ? $baggage : [];
         $this->debugId = $debugId;
     }
 

--- a/tests/Jaeger/SpanContextTest.php
+++ b/tests/Jaeger/SpanContextTest.php
@@ -7,13 +7,31 @@ use PHPUnit\Framework\TestCase;
 
 class SpanContextTest extends TestCase
 {
-    public function test_is_debug_id_container_only()
+    public function testIsDebugIdContainerOnly()
     {
-        $ctx = new SpanContext(null, null, null, null, [], 'value1');
+        $ctx = new SpanContext(null, null, null, null, null, 'value1');
         $this->assertTrue($ctx->isDebugIdContainerOnly());
         $this->assertEquals($ctx->getDebugId(), 'value1');
 
         $ctx = new SpanContext(1, 2, 3, 1);
         $this->assertFalse($ctx->isDebugIdContainerOnly());
+    }
+
+    /**
+     * @dataProvider contextDataProvider
+     */
+    public function testBaggageInit($traceId, $spanId, $parentId, $flags, $baggage, $expected)
+    {
+        $ctx = new SpanContext($traceId, $spanId, $parentId, $flags, $baggage);
+        $this->assertEquals($expected, $ctx->getBaggage());
+    }
+
+    public function contextDataProvider()
+    {
+        return [
+            [null, null, null, null, [], []],
+            [null, null, null, null, null, []],
+            [null, null, null, null, ['key' => 'val'], ['key' => 'val']],
+        ];
     }
 }


### PR DESCRIPTION
In Tracer, we initialize baggage with `null` for root span.
This causes the baggage to be passed onto SpanContext also as `null`
and will cause an exception when we try to merge old and new baggage
array with `+` operand since it will be `[] + null`.

The best fix is probably to ensure baggage is always an array in
SpanContext constructor. The param type hint and `$baggage` property
type hint both uses `array`, so it doesn't make much sense to accept
non-arrays.