### PR TITLE
Support configuring tags to be added to each span

### DIFF
--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -111,7 +111,8 @@ class Config
             null,
             $this->getTraceIdHeader(),
             $this->getBaggageHeaderPrefix(),
-            $this->getDebugIdHeaderKey()
+            $this->getDebugIdHeaderKey(),
+            $this->getConfiguredTags()
         );
     }
 
@@ -271,5 +272,14 @@ class Config
     private function getDebugIdHeaderKey(): string
     {
         return $this->config['debug_id_header_key'] ?? DEBUG_ID_HEADER_KEY;
+    }
+
+    /**
+     * Get a list of user-defined tags to be added to each span created by the tracer initialized by this config.
+     * @return string[]
+     */
+    private function getConfiguredTags(): array
+    {
+        return $this->config['tags'] ?? [];
     }
 }

--- a/src/Jaeger/Tracer.php
+++ b/src/Jaeger/Tracer.php
@@ -64,6 +64,9 @@ class Tracer implements OTTracer
      */
     private $oneSpanPerRpc;
 
+    /**
+     * @var string[]
+     */
     private $tags;
 
     /**

--- a/tests/Jaeger/ConfigTest.php
+++ b/tests/Jaeger/ConfigTest.php
@@ -107,4 +107,27 @@ class ConfigTest extends TestCase
 
         $config->initializeTracer();
     }
+
+    /** @test */
+    public function shouldPassConfiguredTagsToTracer()
+    {
+        $tags = [
+            'bar' => 'a-value',
+            'other.tag' => 'foo',
+        ];
+
+        $config = new Config([
+            'service_name' => 'test-service-name',
+            'tags' => $tags,
+        ]);
+
+        $tracer = $config->initializeTracer();
+        $span = $tracer->startSpan('test-span');
+        $spanTags = $span->getTags();
+
+        foreach ($tags as $name => $value) {
+            $this->assertArrayHasKey($name, $spanTags, "Tag '$name' should be set on span");
+            $this->assertEquals($value, $spanTags[$name]->value, "Tag '$name' should have configured value");
+        }
+    }
 }


### PR DESCRIPTION
Jaeger has a concept of tracer/process tags,[1] which is a list of
tags that should be added to each span started by a given tracer.
This functionality is already implemented in jaeger-client-php,
but currently, there is no configuration option to allow users
to actually define these tags.

This patch extends the Config class to accept a new optional key
'tags', which is a key-value array representing tags that should
be added to each span started by the tracer built from this config.
Some unit tests were added for the new functionality.

---
[1] https://www.jaegertracing.io/docs/1.17/client-features/