### PR TITLE
Migrate away from PHPUnit's expectedException annotations

### DIFF
--- a/tests/Jaeger/Codec/TextCodecTest.php
+++ b/tests/Jaeger/Codec/TextCodecTest.php
@@ -2,6 +2,7 @@
 
 namespace Jaeger\Tests\Codec;
 
+use Exception;
 use const Jaeger\BAGGAGE_HEADER_PREFIX;
 use Jaeger\Codec\TextCodec;
 use const Jaeger\DEBUG_ID_HEADER_KEY;
@@ -127,24 +128,22 @@ class TextCodecTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage baggage without trace ctx
-     */
     public function testBaggageWithoutTraceContext()
     {
         $carrier = [BAGGAGE_HEADER_PREFIX.'test' => 'some data'];
 
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('baggage without trace ctx');
+
         $this->textCodec->extract($carrier);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Malformed tracer state string.
-     */
     public function testInvalidSpanContextParsingFromHeader()
     {
         $carrier = [TRACE_ID_HEADER => 'invalid_data'];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Malformed tracer state string.');
 
         $this->textCodec->extract($carrier);
     }

--- a/tests/Jaeger/ConfigTest.php
+++ b/tests/Jaeger/ConfigTest.php
@@ -47,12 +47,11 @@ class ConfigTest extends TestCase
         $this->assertEquals($this->serviceName, $tracer->getServiceName());
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage service_name required in the config or param.
-     */
     function testThrowExceptionWhenServiceNameIsNotDefined()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('service_name required in the config or param.');
+
         new Config([]);
     }
 
@@ -81,29 +80,27 @@ class ConfigTest extends TestCase
         $this->assertInstanceOf(Tracer::class, $tracer);
     }
 
-    /**
-     * @test
-     * @expectedException Exception
-     * @expectedExceptionMessage Unknown sampler type unsupportedSampler
-     */
+    /** @test */
     public function shouldThrowExceptionWhenCreatingNotSupportedSampler()
     {
         $config = new Config(['service_name' => 'test-service-name', 'sampler' => ['type' => 'unsupportedSampler']]);
 
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unknown sampler type unsupportedSampler');
+
         $config->initializeTracer();
     }
 
-    /**
-     * @test
-     * @expectedException Exception
-     * @expectedExceptionMessage You cannot use RateLimitingSampler without cache component
-     */
+    /** @test */
     public function shouldThrowExceptionWhenCreatingRateLimitingSamplerWithoutCacheComponent()
     {
         $config = new Config([
             'service_name' => 'test-service-name',
-            'sampler' => ['type' => \Jaeger\SAMPLER_TYPE_RATE_LIMITING]]
-        );
+            'sampler' => ['type' => \Jaeger\SAMPLER_TYPE_RATE_LIMITING]
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You cannot use RateLimitingSampler without cache component');
 
         $config->initializeTracer();
     }

--- a/tests/Jaeger/Sampler/ProbablisticSamplerTest.php
+++ b/tests/Jaeger/Sampler/ProbablisticSamplerTest.php
@@ -3,6 +3,7 @@
 namespace Jaeger\Tests\Sampler;
 
 use Jaeger\Sampler\ProbabilisticSampler;
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use const Jaeger\SAMPLER_PARAM_TAG_KEY;
 use const Jaeger\SAMPLER_TYPE_PROBABILISTIC;
@@ -46,11 +47,12 @@ class ProbablisticSamplerTest extends TestCase
      * @test
      * @dataProvider rateProvider
      * @param mixed $rate
-     * @expectedException \OutOfBoundsException
-     * @expectedExceptionMessage Sampling rate must be between 0.0 and 1.0.
      */
     public function shouldThrowOutOfBoundsExceptionInCaseOfInvalidRate($rate)
     {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Sampling rate must be between 0.0 and 1.0.');
+
         new ProbabilisticSampler($rate);
     }
 

--- a/tests/Jaeger/TracerTest.php
+++ b/tests/Jaeger/TracerTest.php
@@ -9,6 +9,7 @@ use Jaeger\ScopeManager;
 use Jaeger\Span;
 use Jaeger\SpanContext;
 use Jaeger\Tracer;
+use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\NoopSpanContext;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -151,15 +152,14 @@ class TracerTest extends TestCase
         $this->assertEquals([], $span->getTags(), 'No tags should be set when not sampled');
     }
 
-    /**
-     * @test
-     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
-     * @expectedExceptionMessage The format 'bad-format' is not supported.
-     */
+    /** @test */
     public function shouldThrowExceptionOnInvalidFormat()
     {
         $spanContext = new SpanContext(0, 0, 0, 0);
         $carrier = [];
+
+        $this->expectException(UnsupportedFormat::class);
+        $this->expectExceptionMessage("The format 'bad-format' is not supported.");
 
         $this->tracer->inject($spanContext, 'bad-format', $carrier);
         $this->assertSame([], $carrier);
@@ -187,14 +187,13 @@ class TracerTest extends TestCase
         $this->assertEquals('0:0:0:0', $carrier[TRACE_ID_HEADER]);
     }
 
-    /**
-     * @test
-     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
-     * @expectedExceptionMessage The format 'bad-format' is not supported.
-     */
+    /** @test */
     public function shouldThrowExceptionOnExtractInvalidFormat()
     {
-        $this->assertNull($this->tracer->extract('bad-format', []));
+        $this->expectException(UnsupportedFormat::class);
+        $this->expectExceptionMessage("The format 'bad-format' is not supported.");
+
+        $this->tracer->extract('bad-format', []);
     }
 
     /** @test */


### PR DESCRIPTION
PHPUnit provides expectedException and related annotations to
declaratively specify information about the exception a test
is expected to throw. This API has been deprecated in PHPUnit 8
and is due to be removed in PHPUnit 9.[1]

This patch migrates the tests to use the recommended expectException()
and related methods instead of the annotations to ensure that a future
PHPUnit upgrade will not break them.

---
[1] https://github.com/sebastianbergmann/phpunit/issues/3332