### PR TITLE
Allow to configure whether to use one span per RPC

### DIFF
--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -106,7 +106,7 @@ class Config
             $this->serviceName,
             $reporter,
             $sampler,
-            true,
+            $this->shouldUseOneSpanPerRpc(),
             $this->logger,
             null,
             $this->getTraceIdHeader(),
@@ -281,5 +281,17 @@ class Config
     private function getConfiguredTags(): array
     {
         return $this->config['tags'] ?? [];
+    }
+
+    /**
+     * Whether to follow the Zipkin model of using one span per RPC,
+     * as opposed to the model of using separate spans on the RPC client and server.
+     * Defaults to true.
+     *
+     * @return bool
+     */
+    private function shouldUseOneSpanPerRpc(): bool
+    {
+        return $this->config['one_span_per_rpc'] ?? true;
     }
 }


### PR DESCRIPTION
Currently, tracers initialized from the Config object are always
configured to follow Zipkin's model of using one span per RPC,
as opposed to the model where a span is always exclusive to a given
tracer (i.e. separate spans on the client and server).

If upstream applications do not follow this model, this can cause
unwanted span ID duplication in traces. This patch makes the option
configurable so that the appropriate behavior can be selected depending
on one's setup. To ensure backwards compatibility, the tracer continues
to default to the Zipkin model if no configuration was set.