### PR TITLE
ARCH-8305: remote_sampler_by_default

### DIFF
--- a/src/Jaeger/Config.php
+++ b/src/Jaeger/Config.php
@@ -169,8 +169,9 @@ class Config
         $samplerType = $samplerConfig['type'] ?? null;
         $samplerParam = $samplerConfig['param'] ?? null;
 
-        if ($samplerType === null) {
-            return new ConstSampler(true);
+        if ($samplerType === null || $samplerType === SAMPLER_TYPE_REMOTE) {
+            // todo: implement remote sampling
+            return new ProbabilisticSampler((float)$samplerParam);
         } elseif ($samplerType === SAMPLER_TYPE_CONST) {
             return new ConstSampler($samplerParam ?? false);
         } elseif ($samplerType === SAMPLER_TYPE_PROBABILISTIC) {

--- a/tests/Jaeger/ConfigTest.php
+++ b/tests/Jaeger/ConfigTest.php
@@ -9,6 +9,7 @@ use Jaeger\Sampler\SamplerInterface;
 use Jaeger\Tracer;
 use OpenTracing\GlobalTracer;
 use PHPUnit\Framework\TestCase;
+use const Jaeger\SAMPLER_TYPE_CONST;
 
 class ConfigTest extends TestCase
 {
@@ -114,6 +115,10 @@ class ConfigTest extends TestCase
         ];
 
         $config = new Config([
+            'sampler' => [
+                'type' => SAMPLER_TYPE_CONST,
+                'param' => true,
+            ],
             'service_name' => 'test-service-name',
             'tags' => $tags,
         ]);


### PR DESCRIPTION
Hey,

According to [the docs](https://www.jaegertracing.io/docs/1.18/sampling/#client-sampling-configuration), `remote` is a default sampler and initial value for sampler is `param` [like in Go implementation](https://github.com/jaegertracing/jaeger-client-go/blob/master/config/config.go#L69-L71).
It enables users to use the same values of env-variables for applications in different languages.
Also, it allows us to add "real remote sampling" latter without breaking changes.