### PR TITLE
added types support for span tags

### DIFF
--- a/src/Jaeger/Mapper/SpanToJaegerMapper.php
+++ b/src/Jaeger/Mapper/SpanToJaegerMapper.php
@@ -3,6 +3,7 @@
 namespace Jaeger\Mapper;
 
 use Jaeger\Span;
+use Jaeger\Thrift\Agent\Zipkin\AnnotationType;
 use Jaeger\Thrift\Agent\Zipkin\BinaryAnnotation;
 use Jaeger\Thrift\Log;
 use Jaeger\Thrift\Span as JaegerThriftSpan;
@@ -57,11 +58,36 @@ class SpanToJaegerMapper
                 continue;
             }
 
+            $type = "";
+            $vkey = "";
+            switch ($binaryAnnotationTag->annotation_type) {
+                case AnnotationType::BOOL:
+                    $type = TagType::BOOL;
+                    $vkey = "vBool";
+                    break;
+                case AnnotationType::BYTES:
+                    $type = TagType::BINARY;
+                    $vkey = "vBinary";
+                    break;
+                case AnnotationType::DOUBLE:
+                    $type = TagType::DOUBLE;
+                    $vkey = "vDouble";
+                    break;
+                case AnnotationType::I16:
+                case AnnotationType::I32:
+                case AnnotationType::I64:
+                    $type = TagType::LONG;
+                    $vkey = "vLong";
+                    break;
+                default:
+                    $type = TagType::STRING;
+                    $vkey = "vStr";
+            }
+
             $tags[] = new Tag([
                 "key" => $binaryAnnotationTag->key,
-                "vType" => TagType::STRING,
-                "vStr" => $binaryAnnotationTag->value,
-
+                "vType" => $type,
+                $vkey => $binaryAnnotationTag->value,
             ]);
         }
 

--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -260,7 +260,7 @@ class Span implements OTSpan
             }
 
             if (!$handled) {
-                $tag = $this->makeStringTag($key, (string) $value);
+                $tag = $this->makeTag($key, $value);
                 $this->tags[$key] = $tag;
             }
         }
@@ -425,18 +425,35 @@ class Span implements OTSpan
 
     /**
      * @param string $key
-     * @param string $value
+     * @param mixed $value
      * @return BinaryAnnotation
      */
-    private function makeStringTag(string $key, string $value): BinaryAnnotation
+    private function makeTag(string $key, $value): BinaryAnnotation
     {
-        if (strlen($value) > 1024) {
-            $value = substr($value, 0, 1024);
+        $valueType = gettype($value);
+        $annotationType = null;
+        switch ($valueType) {
+            case "boolean":
+                $annotationType = AnnotationType::BOOL;
+                break;
+            case "integer":
+                $annotationType = AnnotationType::I64;
+                break;
+            case "double":
+                $annotationType = AnnotationType::DOUBLE;
+                break;
+            default:
+                $annotationType = AnnotationType::STRING;
+                $value = (string)$value;
+                if (strlen($value) > 1024) {
+                    $value = substr($value, 0, 1024);
+                }
         }
+
         return new BinaryAnnotation([
             'key' => $key,
             'value' => $value,
-            'annotation_type' => AnnotationType::STRING,
+            'annotation_type' => $annotationType,
         ]);
     }
 }

--- a/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
+++ b/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+
+use Jaeger\Reporter\NullReporter;
+use Jaeger\Sampler\ConstSampler;
+use Jaeger\Span;
+use Jaeger\SpanContext;
+use Jaeger\Tracer;
+use const Jaeger\SAMPLED_FLAG;
+
+class SpanToJaegerMapperTest extends \PHPUnit\Framework\TestCase
+{
+    private $serviceName = "test-service";
+    /**
+     * @var Tracer
+     */
+    private $tracer;
+
+    /**
+     * @var SpanContext
+     */
+    private $context;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        $this->tracer = new Tracer($this->serviceName, new NullReporter, new ConstSampler);
+        $this->context = new SpanContext(0, 0,0, SAMPLED_FLAG);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        $this->tracer = null;
+        $this->context = null;
+    }
+
+    /** @test */
+    public function shouldProperlyInitializeAtConstructTime(): void
+    {
+        $span = new Span($this->context, $this->tracer, 'test-operation');
+        $span->setTags([
+            "tag-bool1" => true,
+            "tag-bool2" => false,
+            "tag-int" => 1234567,
+            "tag-float" => 1.23456,
+            "tag-string" => "hello-world"
+        ]);
+
+        $mapper = new \Jaeger\Mapper\SpanToJaegerMapper();
+        $thriftSpan = $mapper->mapSpanToJaeger($span);
+
+        $index = 0;
+        $this->assertEquals($thriftSpan->tags[$index]->key, "component");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::STRING);
+        $this->assertEquals($thriftSpan->tags[$index]->vStr, $this->serviceName);
+        $index++;
+
+        $this->assertEquals($thriftSpan->tags[$index]->key, "tag-bool1");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::BOOL);
+        $this->assertEquals($thriftSpan->tags[$index]->vBool, true);
+        $index++;
+
+        $this->assertEquals($thriftSpan->tags[$index]->key, "tag-bool2");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::BOOL);
+        $this->assertEquals($thriftSpan->tags[$index]->vBool, false);
+        $index++;
+
+        $this->assertEquals($thriftSpan->tags[$index]->key, "tag-int");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::LONG);
+        $this->assertEquals($thriftSpan->tags[$index]->vLong, 1234567);
+        $index++;
+
+        $this->assertEquals($thriftSpan->tags[$index]->key, "tag-float");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::DOUBLE);
+        $this->assertEquals($thriftSpan->tags[$index]->vDouble, 1.23456);
+        $index++;
+
+        $this->assertEquals($thriftSpan->tags[$index]->key, "tag-string");
+        $this->assertEquals($thriftSpan->tags[$index]->vType, \Jaeger\Thrift\TagType::STRING);
+        $this->assertEquals($thriftSpan->tags[$index]->vStr, "hello-world");
+        $index++;
+
+    }
+
+}

--- a/tests/Jaeger/SpanTest.php
+++ b/tests/Jaeger/SpanTest.php
@@ -6,6 +6,7 @@ use Jaeger\Reporter\NullReporter;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Span;
 use Jaeger\SpanContext;
+use Jaeger\Thrift\Agent\Zipkin\AnnotationType;
 use Jaeger\Tracer;
 use PHPUnit\Framework\TestCase;
 use const Jaeger\SAMPLED_FLAG;
@@ -87,6 +88,49 @@ class SpanTest extends TestCase
         ]);
 
         $this->assertEquals( 3, count($span->getTags()));
+    }
+
+    /** @test */
+    public function shouldSetDifferentTypeOfTags() {
+        $span = new Span($this->context, $this->tracer, 'test-operation');
+
+        $this->assertEquals( 0, count($span->getTags()));
+
+        $span->setTags([
+            'tag-bool1' => true,
+            'tag-bool2' => false,
+            'tag-int' => 1234567,
+            'tag-float' => 1.23456,
+            'tag-string' => "hello-world"
+        ]);
+
+        $tags = array_values($span->getTags());
+        $this->assertEquals( 5, count($tags));
+
+        $index = 0;
+        $this->assertTrue($tags[$index]->annotation_type === AnnotationType::BOOL);
+        $this->assertTrue($tags[$index]->value === true);
+        $this->assertTrue($tags[$index]->key === 'tag-bool1');
+        $index++;
+
+        $this->assertTrue($tags[$index]->annotation_type === AnnotationType::BOOL);
+        $this->assertTrue($tags[$index]->value === false);
+        $this->assertTrue($tags[$index]->key === 'tag-bool2');
+        $index++;
+
+        $this->assertTrue($tags[$index]->annotation_type === AnnotationType::I64);
+        $this->assertTrue($tags[$index]->value === 1234567);
+        $this->assertTrue($tags[$index]->key === 'tag-int');
+        $index++;
+
+        $this->assertTrue($tags[$index]->annotation_type === AnnotationType::DOUBLE);
+        $this->assertTrue($tags[$index]->value === 1.23456);
+        $this->assertTrue($tags[$index]->key === 'tag-float');
+        $index++;
+
+        $this->assertTrue($tags[$index]->annotation_type === AnnotationType::STRING);
+        $this->assertTrue($tags[$index]->value === "hello-world");
+        $this->assertTrue($tags[$index]->key === 'tag-string');
     }
 
     /** @test */


### PR DESCRIPTION
Now `$span->setTags` support different value types.

Full example: 
```php
<?php

require_once __DIR__."/vendor/autoload.php";

use Jaeger\Config;
use OpenTracing\GlobalTracer;

$config = new Config(
    [
        'sampler' => [
            'type' => Jaeger\SAMPLER_TYPE_CONST,
            'param' => true,
        ],
        'dispatch_mode' => Config::JAEGER_OVER_BINARY_UDP,
        'logging' => true,
    ],

    'your-app-name'
);
$config->initializeTracer();

$tracer = GlobalTracer::get();

$scope = $tracer->startActiveSpan('TestSpan', []);
$scope->getSpan()->setTag("error", true); 
$scope->getSpan()->setTag("bool", true);
$scope->getSpan()->setTag("number", 1);
$scope->getSpan()->setTag("float", 1.22);
$scope->getSpan()->setTag("string", "1.2aaa");
$scope->getSpan()->setTag("fallback-string", NULL);
$scope->close();

$tracer->flush();
```