### PR TITLE
Remove unused library phlib/base_convert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ext-sockets": "*",
         "opentracing/opentracing": "^1.0",
         "packaged/thrift": "^0.13",
-        "phlib/base_convert": "^1.0",
         "psr/cache": "^1.0",
         "psr/log": "^1.0"
     },

--- a/src/Jaeger/Codec/TextCodec.php
+++ b/src/Jaeger/Codec/TextCodec.php
@@ -9,8 +9,6 @@ use const Jaeger\TRACE_ID_HEADER;
 use const Jaeger\BAGGAGE_HEADER_PREFIX;
 use const Jaeger\DEBUG_ID_HEADER_KEY;
 
-use function Phlib\base_convert;
-
 class TextCodec implements CodecInterface
 {
     private $urlEncoding;

--- a/src/Jaeger/Codec/ZipkinCodec.php
+++ b/src/Jaeger/Codec/ZipkinCodec.php
@@ -7,8 +7,6 @@ use Jaeger\SpanContext;
 use const Jaeger\DEBUG_FLAG;
 use const Jaeger\SAMPLED_FLAG;
 
-use function Phlib\base_convert;
-
 class ZipkinCodec implements CodecInterface
 {
     const SAMPLED_NAME = 'X-B3-Sampled';


### PR DESCRIPTION
After #74 we no longer use this library, let's remove it from the dependencies