### PR TITLE
Fixed deprecation warning for symfony and php 7.4

### DIFF
--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -44,6 +44,7 @@ class SpanContext implements OTSpanContext
 
     /**
      * {@inheritdoc}
+     * @return ArrayIterator
      */
     #[\ReturnTypeWillChange]
     public function getIterator()


### PR DESCRIPTION
Fixed deprecation warning for symfony and php 7.4:

`User Deprecated: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "Jaeger\SpanContext" now to avoid errors or add an explicit @return annotation to suppress this message.`