### PR TITLE
Fix SpanToJaegerMapper for short trace id handling

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composercache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/src/Jaeger/Mapper/SpanToJaegerMapper.php
+++ b/src/Jaeger/Mapper/SpanToJaegerMapper.php
@@ -179,8 +179,9 @@ class SpanToJaegerMapper
         }
 
         if (strlen($id) > 16) {
-            $traceIdLow = CodecUtility::hexToInt64(substr($id, -16, 16));
-            $traceIdHigh = CodecUtility::hexToInt64(substr($id, 0, 16));
+            $hiLen = strlen($id) - 16;
+            $traceIdLow = CodecUtility::hexToInt64(substr($id, $hiLen));
+            $traceIdHigh = CodecUtility::hexToInt64(substr($id, 0, $hiLen));
         } else {
             $traceIdLow = (int) CodecUtility::hexToInt64($id);
             $traceIdHigh = 0;

--- a/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
+++ b/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
@@ -173,15 +173,11 @@ class SpanToJaegerMapperTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider traceIdProvider
      * @param string $traceId
-     * @param int $expectedTraceIdHigh
-     * @param int $expectedTraceIdLow
+     * @param int $high
+     * @param int $low
      * @return void
      */
-    public function testShouldCalculateTraceIdHighAndTraceIdLowCorrectly(
-        string $traceId,
-        int $expectedTraceIdHigh,
-        int $expectedTraceIdLow
-    ): void
+    public function testShouldCalculateTraceIdHighAndLow(string $traceId, int $high, int $low): void
     {
         $spanContext = new SpanContext($traceId, 0, 0, SAMPLED_FLAG);
 
@@ -190,8 +186,8 @@ class SpanToJaegerMapperTest extends \PHPUnit\Framework\TestCase
         $mapper = new SpanToJaegerMapper();
         $thriftSpan = $mapper->mapSpanToJaeger($span);
 
-        $this->assertSame($expectedTraceIdHigh, $thriftSpan->traceIdHigh);
-        $this->assertSame($expectedTraceIdLow, $thriftSpan->traceIdLow);
+        $this->assertSame($high, $thriftSpan->traceIdHigh);
+        $this->assertSame($low, $thriftSpan->traceIdLow);
     }
 
     public function traceIdProvider(): array

--- a/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
+++ b/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
@@ -169,4 +169,54 @@ class SpanToJaegerMapperTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider traceIdProvider
+     * @param string $traceId
+     * @param int $expectedTraceIdHigh
+     * @param int $expectedTraceIdLow
+     * @return void
+     */
+    public function testShouldCalculateTraceIdHighAndTraceIdLowCorrectly(
+        string $traceId,
+        int $expectedTraceIdHigh,
+        int $expectedTraceIdLow,
+    ): void
+    {
+        $spanContext = new SpanContext($traceId, 0, 0, SAMPLED_FLAG);
+
+        $span = new Span($spanContext, $this->tracer, 'test-operation');
+
+        $mapper = new SpanToJaegerMapper();
+        $thriftSpan = $mapper->mapSpanToJaeger($span);
+
+        $this->assertSame($expectedTraceIdHigh, $thriftSpan->traceIdHigh);
+        $this->assertSame($expectedTraceIdLow, $thriftSpan->traceIdLow);
+    }
+
+    public function traceIdProvider(): array
+    {
+        return [
+            '32 characters: common' => [
+                'traceId' => '5f2c2ea76d359a165f2c2ea76d35b26b',
+                'expectedTraceIdHigh' => 6857907629205068310,
+                'expectedTraceIdLow' => 6857907629205074539,
+            ],
+            '31 characters: with leading zero' => [
+                'traceId' => '069c546b712128195ba747583accf42c',
+                'expectedTraceIdHigh' => 476348481030662169,
+                'expectedTraceIdLow' => 6604325822831326252,
+            ],
+            '31 characters: short' => [
+                'traceId' => '69c546b712128195ba747583accf42c',
+                'expectedTraceIdHigh' => 476348481030662169,
+                'expectedTraceIdLow' => 6604325822831326252,
+            ],
+            '16 characters: common' => [
+                'traceId' => '5ba747583accf42c',
+                'expectedTraceIdHigh' => 0,
+                'expectedTraceIdLow' => 6604325822831326252,
+            ],
+        ];
+    }
 }

--- a/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
+++ b/tests/Jaeger/Mapper/SpanToJaegerMapperTest.php
@@ -180,7 +180,7 @@ class SpanToJaegerMapperTest extends \PHPUnit\Framework\TestCase
     public function testShouldCalculateTraceIdHighAndTraceIdLowCorrectly(
         string $traceId,
         int $expectedTraceIdHigh,
-        int $expectedTraceIdLow,
+        int $expectedTraceIdLow
     ): void
     {
         $spanContext = new SpanContext($traceId, 0, 0, SAMPLED_FLAG);


### PR DESCRIPTION
Some systems remove leading zeros from trace IDs. This PR adds support for short trace IDs without leading zeros.
Implemented according to the approach of the Golang library [uber/jaeger-client-go](https://github.com/jaegertracing/jaeger-client-go/blob/master/span_context.go#L382).